### PR TITLE
Update dependabot.yml

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -10,3 +10,4 @@ updates:
     schedule:
       interval: "weekly"
     
+    


### PR DESCRIPTION
This pull request includes a small change to the `.github/dependabot.yml` file. The change adds a blank line after the `interval: "weekly"` line to improve readability.

- [`.github/dependabot.yml`](diffhunk://#diff-dd4fbda47e51f1e35defb9275a9cd9c212ecde0b870cba89ddaaae65c5f3cd28R13): Added a blank line after the `interval: "weekly"` line to improve readability.